### PR TITLE
AudioMemory optimization, stage 1

### DIFF
--- a/T41EEE/CWProcessing.cpp
+++ b/T41EEE/CWProcessing.cpp
@@ -360,8 +360,8 @@ void SetKeyPowerUp() {
 *****/
 void SetSideToneVolume() {
   int val, sidetoneDisplay;
-  Q_in_L.clear();  // Clear other buffers too?
-  Q_in_R.clear();
+
+  SetAudioOperatingState(CW_TRANSMIT_STRAIGHT_STATE);
   tft.setFontScale((enum RA8875tsize)1);
   tft.fillRect(SECONDARY_MENU_X - 50, MENUS_Y, EACH_MENU_WIDTH + 60, CHAR_HEIGHT, RA8875_MAGENTA);
   tft.setTextColor(RA8875_WHITE);

--- a/T41EEE/EEPROM.cpp
+++ b/T41EEE/EEPROM.cpp
@@ -49,8 +49,8 @@ void EEPROMRead() {
 #ifdef DEBUG 
     //display version in EEPROM in last line of display
     MORSE_STRING_DISPLAY("EEPROMVersion ");
-    if (strlen(versionSettings) <10) {
-      MORSE_STRING_DISPLAY(versionSettings);
+    if (strlen(EEPROMData.versionSettings) <10) {
+      MORSE_STRING_DISPLAY(EEPROMData.versionSettings);
     }else {
       MORSE_STRING_DISPLAY("<<INVALID>>");
     }

--- a/T41EEE/SDT.h
+++ b/T41EEE/SDT.h
@@ -1139,6 +1139,8 @@ extern AudioEffectCompressor_F32 comp1, comp2;
 extern AudioConvert_F32toI16     float2Int1, float2Int2;    //Converts Float to Int16.  See class in AudioStream_F32.h
 //===============  AFP 11-01-22
 
+extern void SetAudioOperatingState(int operatingState);
+
 extern Bounce decreaseBand;
 extern Bounce increaseBand;
 extern Bounce modeSwitch;

--- a/T41EEE/T41EEE.ino
+++ b/T41EEE/T41EEE.ino
@@ -1931,8 +1931,8 @@ void SetAudioOperatingState(int operatingState) {
         // Microphone input disabled and disconnected
         patchCord1.disconnect();
         patchCord2.disconnect();
-        Q_in_L_Ex.end();
-        Q_in_R_Ex.end();
+        Q_in_L_Ex.end(); Q_in_L_Ex.clear();
+        Q_in_R_Ex.end(); Q_in_R_Ex.clear();
 
         // CW sidetone output disconnected
         patchCord23.disconnect();
@@ -1943,8 +1943,8 @@ void SetAudioOperatingState(int operatingState) {
         // QSD disabled and disconnected
         patchCord9.disconnect();
         patchCord10.disconnect();
-        Q_in_L.end();
-        Q_in_R.end();
+        Q_in_L.end(); Q_in_L.clear();
+        Q_in_R.end(); Q_in_R.clear();
 
         // Microphone input enabled and connected
         Q_in_L_Ex.begin();
@@ -1962,14 +1962,14 @@ void SetAudioOperatingState(int operatingState) {
         // QSD disabled and disconnected
         patchCord9.disconnect();
         patchCord10.disconnect();
-        Q_in_L.end();
-        Q_in_R.end();
+        Q_in_L.end(); Q_in_L.clear();
+        Q_in_R.end(); Q_in_R.clear();
 
         // Microphone input disabled and disconnected
         patchCord1.disconnect();
         patchCord2.disconnect();
-        Q_in_L_Ex.end();
-        Q_in_R_Ex.end();
+        Q_in_L_Ex.end(); Q_in_L_Ex.clear();
+        Q_in_R_Ex.end(); Q_in_R_Ex.clear();
 
         // CW sidetone output connected
         patchCord23.connect();

--- a/T41EEE/T41EEE.ino
+++ b/T41EEE/T41EEE.ino
@@ -2190,6 +2190,40 @@ FASTRUN void loop()  // Replaced entire loop() with Greg's code  JJP  7/14/23
   }
   //lastState = radioState;  // G0ORX 01092023
 
+  //  Manage audio chain memory usage: KN6LFB
+  if (lastState != radioState) {
+#ifdef DEBUG
+    Serial.printf("lastState=%d radioState=%d memory_used=%d memory_used_max=%d f32_memory_used=%d f32_memory_used_max=%d\n",
+                  lastState,
+                  radioState,
+                  (int) AudioStream::memory_used,
+                  (int) AudioStream::memory_used_max,
+                  (int) AudioStream_F32::f32_memory_used,
+                  (int) AudioStream_F32::f32_memory_used_max);
+    AudioStream::memory_used_max = 0;
+    AudioStream_F32::f32_memory_used_max = 0;
+#endif
+    switch (radioState) {
+      case SSB_RECEIVE_STATE:
+      case CW_RECEIVE_STATE:
+        // QSD connected and enabled
+        // Microphone input disabled and disconnected
+        // CW sidetone output disconnected
+        break;
+      case SSB_TRANSMIT_STATE:
+        // QSD disabled and disconnected
+        // Microphone input enabled and connected
+        // CW sidetone output disconnected
+        break;
+      case CW_TRANSMIT_STRAIGHT_STATE:
+      case CW_TRANSMIT_KEYER_STATE:
+        // QSD disabled and disconnected
+        // Microphone input disabled and disconnected
+        // CW sidetone output connected
+        break;
+    }
+  }
+
   //  Begin radio state machines
 
   //  Begin SSB Mode state machine

--- a/T41EEE/T41EEE.ino
+++ b/T41EEE/T41EEE.ino
@@ -2271,11 +2271,6 @@ FASTRUN void loop()  // Replaced entire loop() with Greg's code  JJP  7/14/23
   if (EEPROMData.xmtMode == CW_MODE && (keyPressedOn == 1 && EEPROMData.xmtMode == CW_MODE && EEPROMData.keyType == 1)) radioState = CW_TRANSMIT_KEYER_STATE;
   if (lastState != radioState) {
     SetFreq();  // Update frequencies if the radio state has changed.
-  }
-  //lastState = radioState;  // G0ORX 01092023
-
-  //  Manage audio chain memory usage: KN6LFB
-  if (lastState != radioState) {
     SetAudioOperatingState(radioState);
   }
 

--- a/T41EEE/T41EEE.ino
+++ b/T41EEE/T41EEE.ino
@@ -2207,19 +2207,58 @@ FASTRUN void loop()  // Replaced entire loop() with Greg's code  JJP  7/14/23
       case SSB_RECEIVE_STATE:
       case CW_RECEIVE_STATE:
         // QSD connected and enabled
+        Q_in_L.begin();
+        Q_in_R.begin();
+        patchCord9.connect();
+        patchCord10.connect();
+
         // Microphone input disabled and disconnected
+        patchCord1.disconnect();
+        patchCord2.disconnect();
+        Q_in_L_Ex.end();
+        Q_in_R_Ex.end();
+
         // CW sidetone output disconnected
+        patchCord23.disconnect();
+        patchCord24.disconnect();
+
         break;
       case SSB_TRANSMIT_STATE:
         // QSD disabled and disconnected
+        patchCord9.disconnect();
+        patchCord10.disconnect();
+        Q_in_L.end();
+        Q_in_R.end();
+
         // Microphone input enabled and connected
+        Q_in_L_Ex.begin();
+        Q_in_R_Ex.begin();
+        patchCord1.connect();
+        patchCord2.connect();
+
         // CW sidetone output disconnected
+        patchCord23.disconnect();
+        patchCord24.disconnect();
+
         break;
       case CW_TRANSMIT_STRAIGHT_STATE:
       case CW_TRANSMIT_KEYER_STATE:
         // QSD disabled and disconnected
+        patchCord9.disconnect();
+        patchCord10.disconnect();
+        Q_in_L.end();
+        Q_in_R.end();
+
         // Microphone input disabled and disconnected
+        patchCord1.disconnect();
+        patchCord2.disconnect();
+        Q_in_L_Ex.end();
+        Q_in_R_Ex.end();
+
         // CW sidetone output connected
+        patchCord23.connect();
+        patchCord24.connect();
+
         break;
     }
   }
@@ -2257,10 +2296,6 @@ FASTRUN void loop()  // Replaced entire loop() with Greg's code  JJP  7/14/23
       ShowSpectrum();
       break;
     case SSB_TRANSMIT_STATE:
-      Q_in_L.end();  //Set up input Queues for transmit
-      Q_in_R.end();
-      Q_in_L_Ex.begin();
-      Q_in_R_Ex.begin();
       comp1.setPreGain_dB(EEPROMData.currentMicGain);
       comp2.setPreGain_dB(EEPROMData.currentMicGain);
       if (EEPROMData.compressorFlag == 1) {
@@ -2281,8 +2316,6 @@ FASTRUN void loop()  // Replaced entire loop() with Greg's code  JJP  7/14/23
       modeSelectInExL.gain(0, 1);
       modeSelectOutL.gain(0, 0);
       modeSelectOutR.gain(0, 0);
-      patchCord1.connect();
-      patchCord2.connect();
       modeSelectOutExL.gain(0, EEPROMData.powerOutSSB[EEPROMData.currentBand]);  //AFP 10-21-22
       modeSelectOutExR.gain(0, EEPROMData.powerOutSSB[EEPROMData.currentBand]);  //AFP 10-21-22
       ShowTransmitReceiveStatus();
@@ -2290,10 +2323,6 @@ FASTRUN void loop()  // Replaced entire loop() with Greg's code  JJP  7/14/23
       while (digitalRead(PTT) == LOW) {
         ExciterIQData();
       }
-      Q_in_L_Ex.end();  // End Transmit Queue
-      Q_in_R_Ex.end();
-      Q_in_L.begin();  // Start Receive Queue
-      Q_in_R.begin();
       xrState = RECEIVE_STATE;
       break;
     default:
@@ -2340,8 +2369,6 @@ FASTRUN void loop()  // Replaced entire loop() with Greg's code  JJP  7/14/23
       modeSelectOutR.gain(0, 0);
       modeSelectOutExL.gain(0, 0);
       modeSelectOutExR.gain(0, 0);
-      patchCord1.disconnect();
-      patchCord2.disconnect();
       cwTimer = millis();
       while (millis() - cwTimer <= EEPROMData.cwTransmitDelay) {  //Start CW transmit timer on
         digitalWrite(RXTX, HIGH);
@@ -2381,8 +2408,6 @@ FASTRUN void loop()  // Replaced entire loop() with Greg's code  JJP  7/14/23
       modeSelectOutR.gain(0, 0);
       modeSelectOutExL.gain(0, 0);
       modeSelectOutExR.gain(0, 0);
-      patchCord1.disconnect();
-      patchCord2.disconnect();
       cwTimer = millis();
       while (millis() - cwTimer <= EEPROMData.cwTransmitDelay) {
         digitalWrite(RXTX, HIGH);  //Turns on relay


### PR DESCRIPTION
This change reduces AudioMemory consumption by ensuring that AudioRecordQueues which are not in use are disabled, cleared, and their feeding AudioConnection chains are disconnected at the earliest possible point.

This prevents AudioMemory blocks from accumulating in the AudioRecordQueue (53 blocks per queue), removes any already accumulated blocks, and eliminates AudioMemory use (and processing overhead) between the AudioInputI2SQuad i2s_quadIn and the now disabled queue.

The results are a reduction in AudioMemory usage across the board.  In the CW code paths, particularly, the previous code was near the 500 AudioMemory block limit on receive, and exceeded it on transmit, resulting in CW sidetone distortion, dropouts, and the possibility (although never observed) of CW exciter distortions.  Below are some measurements.

SSB recv
Before:	memory_used_max=108 f32_memory_used_max=6
After:	memory_used=94 f32_memory_used_max=0

SSB xmit
Before:	memory_used_max=142 f32_memory_used_max=6
After:	memory_used_max=54 f32_memory_used_max=6

CW recv
Before:	memory_used_max=474 f32_memory_used_max=0
After:	memory_used_max=156 f32_memory_used_max=0

CW xmit
Before:	memory_used_max=500 f32_memory_used_max=0
After:	memory_used_max=182 f32_memory_used_max=0

This change intentionally does not modify any of the modeSelectXXX.gain() calls or audio mutes/unmutes via digitalWrite() because it would have been beyond the scope of fixing the AudioMemory exhaustion, would have introduced intermediate states into the SetAudioOperatingState function that don't map to radioState, and would have been far more invasive.