### PR TITLE
Interrupt driven buttons, part 2

### DIFF
--- a/T41EEE/Button.cpp
+++ b/T41EEE/Button.cpp
@@ -87,6 +87,7 @@ void ButtonISR() {
         buttonElapsed += BUTTON_USEC_PER_ISR;
       } else {
         buttonADCOut = buttonADCPressed;
+        buttonElapsed = 0;
       }
 
       break;

--- a/T41EEE/Button.cpp
+++ b/T41EEE/Button.cpp
@@ -39,9 +39,9 @@ Thus, the default values below create a filter with 10000 * 0.0217 = 217 Hz band
 
 IntervalTimer buttonInterrupts;
 bool buttonInterruptsEnabled = false;
-unsigned long buttonFilterRegister;
-int buttonState, buttonADCPressed, buttonElapsed;
-volatile int buttonADCOut;
+static unsigned long buttonFilterRegister;
+static int buttonState, buttonADCPressed, buttonElapsed;
+static volatile int buttonADCOut;
 
 /*****
   Purpose: ISR to read button ADC and detect button presses
@@ -181,6 +181,9 @@ int ReadSelectedPushButton() {
     return -1;
   }
   minPinRead = buttonRead;
+  if (!buttonInterruptsEnabled) {
+    MyDelay(100L);
+  }
   return minPinRead;
 }
 

--- a/T41EEE/Button.cpp
+++ b/T41EEE/Button.cpp
@@ -82,7 +82,6 @@ void ButtonISR() {
       break;
     case BUTTON_STATE_PRESSED:
       if (filteredADCValue >= BUTTON_THRESHOLD_RELEASED) {
-        buttonADCOut = BUTTON_OUTPUT_UP;
         buttonState = BUTTON_STATE_UP;
       } else {
         buttonADCOut = buttonADCPressed;
@@ -172,7 +171,7 @@ int ReadSelectedPushButton() {
     press "feel" when calls to ReadSelectedPushButton have variable timing.
     */
 
-    buttonADCOut = 1023;
+    buttonADCOut = BUTTON_OUTPUT_UP;
     interrupts();
   } else {
     while (abs(minPinRead - buttonReadOld) > 3) {  // do averaging to smooth out the button response

--- a/T41EEE/Button.cpp
+++ b/T41EEE/Button.cpp
@@ -32,14 +32,14 @@ Thus, the default values below create a filter with 10000 * 0.0217 = 217 Hz band
 #define BUTTON_STATE_DEBOUNCE     1
 #define BUTTON_STATE_PRESSED      2
 
-#define BUTTON_THRESHOLD_PRESSED  980     // Absolute ADC value
-#define BUTTON_THRESHOLD_RELEASED 1010    // Absolute ADC value
+#define BUTTON_THRESHOLD_PRESSED  970     // Absolute ADC value
+#define BUTTON_THRESHOLD_RELEASED 990     // Absolute ADC value
 #define BUTTON_DEBOUNCE_DELAY     5000    // uSec
-#define BUTTON_REPEAT_DELAY       150000  // uSec
+#define BUTTON_REPEAT_DELAY       200000  // uSec
 
-#define BUTTON_USEC_PER_ISR    (1000000 / BUTTON_FILTER_SAMPLERATE)
+#define BUTTON_USEC_PER_ISR       (1000000 / BUTTON_FILTER_SAMPLERATE)
 
-#define BUTTON_OUTPUT_UP          1023  // Value to be output when in the UP state
+#define BUTTON_OUTPUT_UP          1023    // Value to be output when in the UP state
 
 IntervalTimer buttonInterrupts;
 bool buttonInterruptsEnabled = false;
@@ -60,7 +60,7 @@ void ButtonISR() {
   int filteredADCValue;
 
   buttonFilterRegister = buttonFilterRegister - (buttonFilterRegister >> BUTTON_FILTER_SHIFT) + analogRead(BUSY_ANALOG_PIN);
-  filteredADCValue = (int) buttonFilterRegister >> BUTTON_FILTER_SHIFT;
+  filteredADCValue = (int) (buttonFilterRegister >> BUTTON_FILTER_SHIFT);
 
   switch (buttonState) {
     case BUTTON_STATE_UP:

--- a/T41EEE/EEPROM.cpp
+++ b/T41EEE/EEPROM.cpp
@@ -5,7 +5,7 @@
 //DB2OO, 29-AUG-23: Don't use the overall VERSION for the EEPROM structure version information, but use a combination of an EEPROM_VERSION with the size of the EEPROMData variable.
 // The "EEPROM_VERSION" should only be changed, if the structure config_t EEPROMData has changed!
 // For V049.1 the new version in EEPROM will be "V049_808", for V049.2 it will be "V049_812"
-#define EEPROM_VERSION  "T41EEE.0"
+#define EEPROM_VERSION  "T41EEE.1"
 static char version_size[10];
 
 /*****
@@ -373,6 +373,7 @@ void EEPROMStartup() {
   if (strcmp(EEPROMData.versionSettings, EEPROMSetVersion()) == 0) {  // Are the versions the same?
     return;                                                // Yep. Go home and don't mess with the EEPROM
   }
+
   strcpy(EEPROMData.versionSettings, EEPROMSetVersion());  // Nope, this is a new the version, so copy new version title to EEPROM
                                                 //                                                                     Check if calibration has not been done and/or switch values are wonky, okay to use defaults
                                                 //                                                                     If the Teensy is unused, these EEPROM values are 0xFF or perhaps cleared to 0.

--- a/T41EEE/MenuProc.cpp
+++ b/T41EEE/MenuProc.cpp
@@ -23,8 +23,8 @@ int CalibrateOptions() {
 
   // Select the type of calibration, and then skip this during the loop() function.
   if (calibrateFlag == 0) {
-    const char *IQOptions[7]{ "Freq Cal", "CW PA Cal", "Rec Cal", "Xmit Cal", "SSB PA Cal", "Set Tone", "Cancel" };  //AFP 10-21-22
-    IQChoice = SubmenuSelect(IQOptions, 7, 0);                                                                       //AFP 10-21-22
+    const char *IQOptions[9]{ "Freq Cal", "CW PA Cal", "Rec Cal", "Xmit Cal", "SSB PA Cal", "Set Tone", "Btn Cal", "Btn Repeat", "Cancel" };  //AFP 10-21-22
+    IQChoice = SubmenuSelect(IQOptions, 9, 0);                                                                       //AFP 10-21-22
   }
   calibrateFlag = 1;
   switch (IQChoice) {
@@ -95,7 +95,31 @@ int CalibrateOptions() {
       return 0;
       break;
 
-    case 6:  // Cancelled choice
+    case 6:  // Calibrate buttons
+      SaveAnalogSwitchValues();
+      calibrateFlag = 0;
+      RedrawDisplayScreen();
+      ShowFrequency();
+      DrawFrequencyBarValue();
+      IQChoice = 6;
+      return 6;
+
+    case 7:  // Set button repeat rate
+      EEPROMData.buttonRepeatDelay = 1000 * GetEncoderValueLive(0, 5000, EEPROMData.buttonRepeatDelay / 1000, 1, (char *)"Btn Repeat:  ");
+      val = ReadSelectedPushButton();
+      if (val != BOGUS_PIN_READ) {
+        val = ProcessButtonPress(val);
+        if (val == MENU_OPTION_SELECT) {
+          tft.fillRect(SECONDARY_MENU_X, MENUS_Y, EACH_MENU_WIDTH + 35, CHAR_HEIGHT, RA8875_BLACK);
+          EEPROMWrite();
+          calibrateFlag = 0;
+          IQChoice = 7;
+          return IQChoice;
+        }
+      }
+      break;
+
+    case 8:  // Cancelled choice
       //EraseMenus();
       RedrawDisplayScreen();
       currentFreq = TxRxFreq = EEPROMData.centerFreq + NCOFreq;

--- a/T41EEE/SDT.h
+++ b/T41EEE/SDT.h
@@ -1491,6 +1491,7 @@ extern int mainTuneEncoder;
 extern int micChoice;
 extern int micGainChoice;
 extern int minPinRead;
+extern bool buttonInterruptsEnabled;
 extern int NR_Filter_Value;
 extern int operatingMode;
 extern int n_L;

--- a/T41EEE/SDT.h
+++ b/T41EEE/SDT.h
@@ -3,7 +3,7 @@
 
 //======================================== User section that might need to be changed ===================================
 #include "MyConfigurationFile.h"                                          // This file name should remain unchanged
-#define VERSION                     "T41EEE.0"                               // Change this for updates. If you make this longer than 9 characters, brace yourself for surprises
+#define VERSION                     "T41EEE.1"                            // Change this for updates. If you make this longer than 9 characters, brace yourself for surprises
 #define UPDATE_SWITCH_MATRIX        0                                     // 1 = Yes, redo the switch matrix values, 0 = leave switch matrix values as is from the last change
 struct maps {
   char mapNames[50];
@@ -829,6 +829,9 @@ int lastFrequencies[NUMBER_OF_BANDS][2] = {{3985000, 3560000}, {7200000, 7030000
   bool xmitEQFlag = false;
   bool receiveEQFlag = false;
   int calFreq = 1;  // This is an index into an array of tone frequencies, for example:  {750, 3000}
+  int buttonThresholdPressed = 934;
+  int buttonThresholdReleased = 944;
+  int buttonRepeatDelay = 200000;
 };                                 //  Total:       438 bytes
 
 extern struct config_t EEPROMData;

--- a/T41EEE/SDT.h
+++ b/T41EEE/SDT.h
@@ -829,8 +829,8 @@ int lastFrequencies[NUMBER_OF_BANDS][2] = {{3985000, 3560000}, {7200000, 7030000
   bool xmitEQFlag = false;
   bool receiveEQFlag = false;
   int calFreq = 1;  // This is an index into an array of tone frequencies, for example:  {750, 3000}
-  int buttonThresholdPressed = 934;
-  int buttonThresholdReleased = 944;
+  int buttonThresholdPressed = 944; // switchValues[0] + WIGGLE_ROOM
+  int buttonThresholdReleased = 964; // buttonThresholdPressed + WIGGLE_ROOM
   int buttonRepeatDelay = 200000;
 };                                 //  Total:       438 bytes
 

--- a/T41EEE/T41EEE.ino
+++ b/T41EEE/T41EEE.ino
@@ -2055,26 +2055,8 @@ void setup() {
   EEPROMData.sdCardPresent = InitializeSDCard();  // Is there an SD card that can be initialized?
 
   // =============== EEPROM section =================
-  EEPROMStartup();
-
-
-  // Push and hold a button at power up to activate switch matrix calibration.
-  // Uncomment this code block to enable this feature.  Len KD0RC
-  /* Remove this line and the matching block comment line below to activate.
-  minPinRead = analogRead(BUSY_ANALOG_PIN);
-  if (minPinRead < NOTHING_TO_SEE_HERE) {
-    tft.fillWindow(RA8875_BLACK);
-    tft.setFontScale(1);
-    tft.setTextColor(RA8875_GREEN);
-    tft.setCursor(10, 10);
-    tft.print("Release button to start calibration.");
-    MyDelay(2000);
-    SaveAnalogSwitchValues();
-    EEPROMRead();  // Call to reset switch matrix values
-  }                // KD0RC end
-  Remove this line and the matching block comment line above to activate. */
-
   EnableButtonInterrupts();
+  EEPROMStartup();
 
   spectrum_x = 10;
   spectrum_y = 150;

--- a/T41EEE/Utility.cpp
+++ b/T41EEE/Utility.cpp
@@ -257,7 +257,7 @@ void Calculatedbm()
   // calculation of the signal level inside the filter bandwidth
   // taken from the spectrum display FFT
   // taking into account the analog gain before the ADC
-  // analog gain is adgusted in steps of 1.5dB
+  // analog gain is adjusted in steps of 1.5dB
   // bands[EEPROMData.currentBand].RFgain = 0 --> 0dB gain
   // bands[EEPROMData.currentBand].RFgain = 15 --> 22.5dB gain
 

--- a/T41EEE/Utility.cpp
+++ b/T41EEE/Utility.cpp
@@ -495,6 +495,7 @@ void SaveAnalogSwitchValues()
                                 };
   */
   int index;
+  int minVal;
   int value;
   int origRepeatDelay;
 
@@ -522,8 +523,25 @@ void SaveAnalogSwitchValues()
     tft.print(". ");
     tft.print(labels[index]);
 
-    while ((value = ReadSelectedPushButton()) == -1) {
-      // Wait until a button is pressed
+    if (buttonInterruptsEnabled) {
+      while ((value = ReadSelectedPushButton()) == -1) {
+        // Wait until a button is pressed
+      }
+    } else {
+      value = -1;
+      minVal = NOTHING_TO_SEE_HERE;
+      while (true) {
+        value = ReadSelectedPushButton();
+        if (value < NOTHING_TO_SEE_HERE && value > 0) {
+          MyDelay(100L);
+          if (value < minVal) {
+            minVal = value;
+          } else {
+            value = minVal;
+            break;
+          }
+        }
+      }
     }
 
     tft.fillRect(20, 100, 300, 40, RA8875_BLACK);
@@ -542,7 +560,7 @@ void SaveAnalogSwitchValues()
     }
 
     index++;
-    while ((value = ReadSelectedPushButton()) != -1) {
+    while ((value = ReadSelectedPushButton()) != -1 && value < NOTHING_TO_SEE_HERE) {
       // Wait until the button is released
     }
   }

--- a/T41EEE/Utility.cpp
+++ b/T41EEE/Utility.cpp
@@ -257,7 +257,7 @@ void Calculatedbm()
   // calculation of the signal level inside the filter bandwidth
   // taken from the spectrum display FFT
   // taking into account the analog gain before the ADC
-  // analog gain is adjusted in steps of 1.5dB
+  // analog gain is adgusted in steps of 1.5dB
   // bands[EEPROMData.currentBand].RFgain = 0 --> 0dB gain
   // bands[EEPROMData.currentBand].RFgain = 15 --> 22.5dB gain
 
@@ -495,10 +495,14 @@ void SaveAnalogSwitchValues()
                                 };
   */
   int index;
-  int minVal;
   int value;
+  int origRepeatDelay;
 
-  tft.fillWindow(RA8875_BLACK);
+  tft.clearMemory();  // Need to clear overlay too
+  tft.writeTo(L2);
+  tft.fillWindow();
+  tft.writeTo(L1);
+  tft.clearScreen(RA8875_BLACK);
   tft.setFontScale(1);
   tft.setTextColor(RA8875_GREEN);
   tft.setCursor(10, 10);
@@ -508,38 +512,42 @@ void SaveAnalogSwitchValues()
   tft.setCursor(10, 50);
   tft.print("the switch shown.");
 
+  // Disable button repeat for interrupt driven buttons
+  origRepeatDelay = EEPROMData.buttonRepeatDelay;
+  EEPROMData.buttonRepeatDelay = 0;
+
   for (index = 0; index < NUMBER_OF_SWITCHES; ) {
     tft.setCursor(20, 100);
     tft.print(index + 1);
     tft.print(". ");
     tft.print(labels[index]);
-    value = -1;
-    minVal = NOTHING_TO_SEE_HERE;
-    while (true) {
-      value = ReadSelectedPushButton();
-      if (value < NOTHING_TO_SEE_HERE && value > 0) {
-        MyDelay(100L);
-        if (value < minVal) {
-          minVal = value;
-        } else {
-          value = -1;
-          break;
-        }
-      }
+
+    while ((value = ReadSelectedPushButton()) == -1) {
+      // Wait until a button is pressed
     }
-    if (value == -1) {
-      tft.fillRect(20, 100, 300, 40, RA8875_BLACK);
-      tft.setCursor(350, 20 + index * 25);
-      tft.print(index + 1);
-      tft.print(". ");
-      tft.print(labels[index]);
-      tft.setCursor(660, 20 + index * 25);
-      tft.print(minVal);
-      EEPROMData.switchValues[index] = minVal;
-      index++;
-      MyDelay(100L);
+
+    tft.fillRect(20, 100, 300, 40, RA8875_BLACK);
+    tft.setCursor(350, 20 + index * 25);
+    tft.print(index + 1);
+    tft.print(". ");
+    tft.print(labels[index]);
+    tft.setCursor(660, 20 + index * 25);
+    tft.print(value);
+    EEPROMData.switchValues[index] = value;
+
+    // Set interrupt press/release thresholds based on the Select button, which has the highest ADC value
+    if (index == 0) {
+      EEPROMData.buttonThresholdPressed = EEPROMData.switchValues[0] + WIGGLE_ROOM;
+      EEPROMData.buttonThresholdReleased = EEPROMData.buttonThresholdPressed + WIGGLE_ROOM;
+    }
+
+    index++;
+    while ((value = ReadSelectedPushButton()) != -1) {
+      // Wait until the button is released
     }
   }
+
+  EEPROMData.buttonRepeatDelay = origRepeatDelay;   // Restore original repeat delay
   EEPROM.put(0, EEPROMData);                        // Save values to EEPROM
 }
 


### PR DESCRIPTION
This is a much simplified and improved implementation of my interrupt driven button code.

### Highlights
1. Retains the software LPF to manage the extremely high amount of noise on the button ADC values.  Sample rate has been increased to 10kHz and effective bandwidth to 217Hz.
2. Simpler, traditional debounce logic using a state machine and a fixed delay.
3. Retains the original polling function interface, as the previous version did.
4. Improved repeat logic that attempts to deal with timing variability in code paths that call the old polling routines.
5. Refactored SaveAnalogSwitchValues to provide a nicer user experience/eliminate key repeats when setting values (this fix available with or without button interrupts).
6. Enable button interrupts by default.
7. Added "Btn Cal" and "Btn Repeat" menu choices to the Calibration menu.  "Btn Cal" allows the user to run through the button value calibration logic.  "Btn Repeat" allows the user to adjust the button press repeat rate for interrupt driven buttons (does not apply to non-interrupt driven buttons).  A "Btn Repeat" of 0 disables repeat.

### EEPROM
This change adds three values to the EEPROM:

1. buttonThresholdPressed
2. buttonThresholdReleased
3. buttonRepeatDelay

buttonThresholdPressed and buttonThresholdReleased are set in SaveAnalogSwitchValues based on the value of the Select (highest ADC value) button, and define the threshold ADC values for triggering press and release (see below).

buttonRepeatDelay is stored in microseconds to reduce calculation time in the ISR and defaults to 200ms.

I incremented the EEPROM and software versions to T41EEE.1 in order to reflect these EEPROM changes.  Not sure if that's how you want to handle such things.  Please let me know.

**Note:** I was unsure how to integrate these changes into the JSON save/restore logic (mostly the restore, since I don't know how you want to handle missing values), so that has not yet been implemented.

### Debounce Algorithm
This implementation uses a traditional state machine based debounce:

1. Detect button press
2. Delay until press has settled
3. Read value

Things are slightly complicated in the T41 because we are using an analog input and it is unbelievably noisy.  This code applies a software LPF to filter out the noise.  The debounce delay interacts with the LPF in two ways:

1. Negative: we have to wait until the filtered values have settled, so changes to the amount of smoothing impact the shortest possible debounce delay
2. Positive: since the values are filtered, they're generally pretty usable immediately after the filter settling time

To arrive at appropriate characteristics for the filter and the delay, I captured button press waveforms on my oscilloscope and then simulated the filter and debounce logic in software.  Here are some results using the sampling rate, filter bandwidth, and delay characteristics that are in this implementation:

![Button1PressRelease](https://github.com/Greg-R/T41EEE/assets/32805192/818c6d40-2490-4ad4-b539-be301c474955)

![Button5PressRelease](https://github.com/Greg-R/T41EEE/assets/32805192/7aad11b1-3d5d-454e-a50f-0d9f66582182)

![FastMultiButtonPressRelease](https://github.com/Greg-R/T41EEE/assets/32805192/be3df2a3-cb3a-44ed-901d-7e2c325334f1)

Each simulation has three dotted lines indicating the following events:

1. Initial press detection
2. Read of filtered value
3. Button "up" detection

In the **FastMultiButtonPressRelease** example, I raked my fingers across the buttons to generate many very fast clicks.  With the smoothing and threshold values in that simulation, only the first button press will be "detected", as the filtered ADC values don't rise above the "button up" threshold.  I feel that this shows a decent balance in the current parameters between sensitivity and avoiding spurious button clicks.

### Key Repeat
In order to provide a usable, asynchronous, and somewhat consistent key repeat, the button ISR simulates individual key presses at the repeat interval.  That is, after a value has been read, **buttonADCOut** is reset to the unpressed button value **BUTTON_OUTPUT_UP**.  The internal ISR button state machine still considers the button to be pressed as long as the physical button remains pressed and the ISR outputs single **buttonADCOut** pulses at the repeat delay.

This allows the polling function interface to be retained, and compensates for the highly variable timing between calls to those functions.  It also allows very quick button presses to be "remembered" and processed once the main T41 loop gets around to checking the buttons.