### PR TITLE
Buttons disabled during transmit

### DIFF
--- a/T41EEE/T41EEE.ino
+++ b/T41EEE/T41EEE.ino
@@ -2172,12 +2172,10 @@ FASTRUN void loop()  // Replaced entire loop() with Greg's code  JJP  7/14/23
   bool cwKeyDown;
   unsigned long cwBlockIndex;
 
-  valPin = ReadSelectedPushButton();                     // Poll UI push buttons
-  if (valPin != BOGUS_PIN_READ) {                        // If a button was pushed...
-    pushButtonSwitchIndex = ProcessButtonPress(valPin);  // Winner, winner...chicken dinner!
-    if (xrState == RECEIVE_STATE) {
-      ExecuteButtonPress(pushButtonSwitchIndex);
-    }
+  valPin = ReadSelectedPushButton();
+  if (valPin != BOGUS_PIN_READ && xrState != TRANSMIT_STATE) {
+    pushButtonSwitchIndex = ProcessButtonPress(valPin);
+    ExecuteButtonPress(pushButtonSwitchIndex);
   }
   //  State detection
   if (EEPROMData.xmtMode == SSB_MODE && digitalRead(PTT) == HIGH) radioState = SSB_RECEIVE_STATE;

--- a/T41EEE/T41EEE.ino
+++ b/T41EEE/T41EEE.ino
@@ -2175,7 +2175,9 @@ FASTRUN void loop()  // Replaced entire loop() with Greg's code  JJP  7/14/23
   valPin = ReadSelectedPushButton();                     // Poll UI push buttons
   if (valPin != BOGUS_PIN_READ) {                        // If a button was pushed...
     pushButtonSwitchIndex = ProcessButtonPress(valPin);  // Winner, winner...chicken dinner!
-    ExecuteButtonPress(pushButtonSwitchIndex);
+    if (xrState == RECEIVE_STATE) {
+      ExecuteButtonPress(pushButtonSwitchIndex);
+    }
   }
   //  State detection
   if (EEPROMData.xmtMode == SSB_MODE && digitalRead(PTT) == HIGH) radioState = SSB_RECEIVE_STATE;


### PR DESCRIPTION
Hi Greg,

This one line modification disables execution of button presses while in transmit mode.

There are some code paths, for example, CW PA Cal, where noise during transmit can trigger spurious button presses.  My T41 experiences this problem on 15 meters and above.  Jerry, KF6VB, reported a similar issue with EMI on his T41 here:

https://groups.io/g/SoftwareControlledHamRadio/topic/94020434#19237

This change reads the buttons but just avoids processing them while in transmit mode.  This effectively drains the key repeat for interrupt driven buttons and prevents spurious presses when existing transmit mode.  If interrupt driven buttons are not being used, this code retains the previous timing/delays present in **ReadSelectedPushButton**.
