### PR TITLE
Bugfix: Keyer speed is reset to 15wpm on center frequency change

### DIFF
--- a/T41EEE/CWProcessing.cpp
+++ b/T41EEE/CWProcessing.cpp
@@ -390,11 +390,9 @@ void MorseCharacterDisplay(char currentLetter) {
     void
 *****/
 void ResetHistograms() {
-  gapAtom = 80;
-  ditLength = 80;  // Start with 15wpm ditLength
-  gapChar = 240;
-  dahLength = 240;
-  thresholdGeometricMean = 160;  // Use simple mean for starters so we don't have 0
+  gapAtom = ditLength = transmitDitLength;
+  gapChar = dahLength = transmitDitLength * 3;
+  thresholdGeometricMean = (ditLength + dahLength) / 2;  // Use simple mean for starters so we don't have 0
   aveDitLength = ditLength;
   aveDahLength = dahLength;
   valRef1 = 0;
@@ -402,8 +400,6 @@ void ResetHistograms() {
   // Clear graph arrays
   memset(signalHistogram, 0, HISTOGRAM_ELEMENTS * sizeof(uint32_t));
   memset(gapHistogram, 0, HISTOGRAM_ELEMENTS * sizeof(uint32_t));
-  EEPROMData.currentWPM = 1200 / ditLength;
-  UpdateWPMField();
 }
 
 


### PR DESCRIPTION
Somewhere between V049.2 and https://github.com/Greg-R/T41EEE/commit/68ac032c9bb99bfc03c5869912f2300fc9aa1e79, code was added to **ResetHistograms** that forcibly set EEPROMData.currentWPM to 15.

**ResetHistograms** is called from **EncoderCenterTune** whenever the center tune encoder is turned and the CW decoder is enabled.

```
  if (EEPROMData.xmtMode == CW_MODE && EEPROMData.decoderFlag == DECODE_ON) {  // No reason to reset if we're not doing decoded CW AFP 09-27-22
    ResetHistograms();
  }
```

Note that the internal CW timing (transmitDitLength, et al.) is not updated, so the keyer speed doesn't immediately change, and it is not immediately apparent that the configured keyer speed has been overwritten.

This change modifies **ResetHistograms** to behave as described in its Purpose comment: the initial timing is based off of the already calculated transmitDitLength, and removes the assignment of EEPROMData.currentWPM.  Additionally, since the keyer speed is not being changed, I removed the now-unnecessary call to **UpdateWPMField**.

